### PR TITLE
fix get metrics uri contains resources_filter

### DIFF
--- a/pkg/client/monitoring/client.go
+++ b/pkg/client/monitoring/client.go
@@ -42,10 +42,18 @@ func SendMonitoringRequest(uriPath string, extraQueryParams string, metrics []st
 		queryParams = queryParams + "&" + extraQueryParams
 	}
 
-	if strings.HasPrefix(uriPath, "http://") || strings.HasPrefix(uriPath, "https://") {
-		urlStr = uriPath + "&" + queryParams
+	if strings.Contains(uriPath, "?") {
+		if strings.HasPrefix(uriPath, "http://") || strings.HasPrefix(uriPath, "https://") {
+			urlStr = uriPath + "&" + queryParams
+		} else {
+			urlStr = DefaultScheme + "://" + uriPath + "&" + queryParams
+		}
 	} else {
-		urlStr = DefaultScheme + "://" + uriPath + "&" + queryParams
+		if strings.HasPrefix(uriPath, "http://") || strings.HasPrefix(uriPath, "https://") {
+			urlStr = uriPath + "?" + queryParams
+		} else {
+			urlStr = DefaultScheme + "://" + uriPath + "?" + queryParams
+		}
 	}
 
 	logger.Info(nil, "SendMonitoringRequest %s", urlStr)


### PR DESCRIPTION
pkg/adapter/kubesphere/kubesphere.go the 90 raw, uri will be contains "?resources_filter=" , lead to getting metrics failed